### PR TITLE
feat(user): 이메일, 닉네임을 각각 중복 체크하는 api 구현

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -85,6 +85,21 @@ const userController = {
 
     return res.status(StatusCodes.NO_CONTENT).end();
   }),
+
+  checkNickname: errorHandler(async (req, res) => {
+    const { connection } = req;
+    const { nickname } = req.body;
+
+    const user = await userService.getUserByNickname({ connection, nickname });
+
+    if (user) {
+      return res
+        .status(StatusCodes.CONFLICT)
+        .json({ message: "이미 존재하는 닉네임 입니다." });
+    }
+
+    return res.status(StatusCodes.NO_CONTENT).end();
+  }),
 };
 
 export default userController;

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -70,6 +70,21 @@ const userController = {
     res.clearCookie(ACCESS_TOKEN_KEY);
     return res.status(StatusCodes.NO_CONTENT).end();
   }),
+
+  checkEmail: errorHandler(async (req, res) => {
+    const { connection } = req;
+    const { email } = req.body;
+
+    const user = await userService.getUserByEmail({ connection, email });
+
+    if (user) {
+      return res
+        .status(StatusCodes.CONFLICT)
+        .json({ message: "이미 존재하는 이메일 입니다." });
+    }
+
+    return res.status(StatusCodes.NO_CONTENT).end();
+  }),
 };
 
 export default userController;

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -14,4 +14,6 @@ router.post("/login", [...userValidator.getLoginValidator()], userController.log
 
 router.post("/logout", [loginRequired], userController.logout);
 
+router.post("/check-email", [...userValidator.getCheckEmailValidator()], userController.checkEmail);
+
 export default router;

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -8,12 +8,24 @@ router.use(express.json());
 
 router.post("/auth", userController.auth);
 
-router.post("/signup", [...userValidator.getSignupValidator()], userController.signup);
+router.post(
+  "/signup",
+  [...userValidator.getSignupValidator()],
+  userController.signup
+);
 
-router.post("/login", [...userValidator.getLoginValidator()], userController.login);
+router.post(
+  "/login",
+  [...userValidator.getLoginValidator()],
+  userController.login
+);
 
 router.post("/logout", [loginRequired], userController.logout);
 
-router.post("/check-email", [...userValidator.getCheckEmailValidator()], userController.checkEmail);
+router.post(
+  "/check-email",
+  [...userValidator.getCheckEmailValidator()],
+  userController.checkEmail
+);
 
 export default router;

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -28,4 +28,10 @@ router.post(
   userController.checkEmail
 );
 
+router.post(
+  "/check-nickname",
+  [...userValidator.getCheckNicknameValidator()],
+  userController.checkNickname
+);
+
 export default router;

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -30,6 +30,10 @@ const userValidator = {
   getLoginValidator() {
     return createValidator(createEmailChain, createPasswordChain);
   },
+
+  getCheckEmailValidator() {
+    return createValidator(createEmailChain);
+  },
 };
 
 export default userValidator;

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -34,6 +34,10 @@ const userValidator = {
   getCheckEmailValidator() {
     return createValidator(createEmailChain);
   },
+
+  getCheckNicknameValidator() {
+    return createValidator(createNicknameChain);
+  },
 };
 
 export default userValidator;


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 기존에 있는 `getUserByNickname` 메서드와 `getUserByEmail` 메서드를 이용해서 중복 체크하는 API를 각각 구현했습니다.

### PR Point
- FE 팀에서 적용한 정규표현식을 validator에 적용해야 하는데 새로운 Issue로 만들었고 다른 PR로 올릴 예정입니다.

### 📸 스크린샷

- 이메일 중복 체크 API

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/3408a0ee-4273-4941-8b73-b871b6c851b2)|중복되지 않을 경우 204 응답|
|![image](https://github.com/Pogakco/BE/assets/123533586/cf9c77e5-e988-437c-887b-c21ccfdc8f9b)|이메일이 중복될 경우 에러 메세지 반환|
|![image](https://github.com/Pogakco/BE/assets/123533586/3863284f-4bd0-4bb3-8740-12a1ba534be3)|body에 `email`이 없을 경우 에러 메세지 반환|


- 닉네임 중복 체크 API

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/c6e3b1c4-b957-48cc-879d-1c35561eba7e)|중복되지 않을 경우 204 응답|
|![image](https://github.com/Pogakco/BE/assets/123533586/b3833e44-82ba-46e1-871c-4f95b7673912)|닉네임이 중복될 경우 에러 메세지 반환|
|![image](https://github.com/Pogakco/BE/assets/123533586/f6ef406f-d382-4bd7-b09d-893cfeb1d526)|body에 `nickname`이 없을 경우 에러 메세지 반환|


closed #12 
