### PR TITLE
feat(user-validator): nickname, password 필드에 정규 표현식 유효성 검사 적용

### DIFF
--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -12,9 +12,24 @@ const createEmailChain = () => {
 
 const createNicknameChain = () => {
   return body("nickname").notEmpty().withMessage("닉네임을 입력해 주세요.");
+const createSignupPasswordChain = () => {
+  // 알파벳, 숫자, 특수문자가 1개씩 포함되는 8-20자 내의 값
+  const alphabets = "A-Za-z";
+  const numbers = "\\d";
+  const specialChars = "@$!%*#?&";
+  const regex = new RegExp(
+    `^(?=.*[${alphabets}])(?=.*[${numbers}])(?=.*[${specialChars}])[${alphabets}${numbers}${specialChars}]{8,20}$`
+  );
+
+  return body("password")
+    .notEmpty()
+    .withMessage("비밀번호를 입력해 주세요.")
+    .bail()
+    .matches(regex)
+    .withMessage("비밀번호를 형식에 맞게 입력해 주세요.");
 };
 
-const createPasswordChain = () => {
+const createLoginPasswordChain = () => {
   return body("password").notEmpty().withMessage("비밀번호를 입력해 주세요.");
 };
 
@@ -23,12 +38,12 @@ const userValidator = {
     return createValidator(
       createEmailChain,
       createNicknameChain,
-      createPasswordChain
+      createSignupPasswordChain
     );
   },
 
   getLoginValidator() {
-    return createValidator(createEmailChain, createPasswordChain);
+    return createValidator(createEmailChain, createLoginPasswordChain);
   },
 };
 

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -11,7 +11,22 @@ const createEmailChain = () => {
 };
 
 const createNicknameChain = () => {
-  return body("nickname").notEmpty().withMessage("닉네임을 입력해 주세요.");
+  // 1. 문자열의 시작부터 연속된 두 개 이상의 공백이 불가능하고, 앞뒤에 공백이 올 수 없음
+  // 2. 숫자, 영어, 완성형 한글(가-힣)만 포함될 수 있음
+  // 3. 2-10자 내의 값
+  const validChars = "0-9a-zA-Z가-힣";
+  const regex = new RegExp(
+    `^(?!.*\\s{2,})[${validChars}][${validChars}\\s]{0,8}[${validChars}]$`
+  );
+
+  return body("nickname")
+    .notEmpty()
+    .withMessage("닉네임을 입력해 주세요.")
+    .bail()
+    .matches(regex)
+    .withMessage("닉네임을 형식에 맞게 입력해 주세요.");
+};
+
 const createSignupPasswordChain = () => {
   // 알파벳, 숫자, 특수문자가 1개씩 포함되는 8-20자 내의 값
   const alphabets = "A-Za-z";


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 공통으로 사용되는 `nickname` 필드에 정규표현식 유효성 검사를 추가했습니다.
  - 문자열의 시작부터 연속된 두 개 이상의 공백이 불가능하고, 앞뒤에 공백이 올 수 없음
  - 숫자, 영어, 완성형 한글(가-힣)만 포함될 수 있음
  - 2-10자 내의 값
- 회원가입시 사용되는 `password` 필드에 정규표현식 유효성 검사를 추가했습니다.
  - 알파벳, 숫자, 특수문자가 1개씩 포함되는 8-20자 내의 값

### PR Point
- [정규표현식 테스트 페이지](https://regex101.com/)에서 예외 값들, 정상적인 값들로 몇 번 테스트 부탁드립니다!
  - **nickname 필드 정규 표현식**: `^(?!.*\s{2,})([0-9a-zA-Z가-힣][0-9a-zA-Z가-힣\s]{0,8}[0-9a-zA-Z가-힣])$`
  - **password 필드 정규 표현식**: `/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,20}$/`

### 📸 스크린샷
|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/41ed828d-7ffc-42b6-884c-53da5adb5336)|닉네임 유효성 검사를 먼저 한 이후 비밀번호 검사로 넘어가게 됩니다.|


closed #14
