### PR TITLE
feat(user): 내 프로필 api 구현

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -100,6 +100,14 @@ const userController = {
 
     return res.status(StatusCodes.NO_CONTENT).end();
   }),
+
+  myProfile: errorHandler(async (req, res) => {
+    const { connection, userId } = req;
+
+    const profile = await userService.getUserProfile({ connection, userId });
+
+    return res.status(StatusCodes.OK).json(profile);
+  }),
 };
 
 export default userController;

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -1,6 +1,14 @@
 import isEmptyArray from "../utils/isEmptyArray.js";
 
 const userRepository = {
+  async findUserById({ connection, userId }) {
+    const SQL = "SELECT * FROM `users` WHERE `id` = ?";
+
+    const [data] = await connection.query(SQL, [userId]);
+
+    return isEmptyArray(data) ? null : data[0];
+  },
+
   async findUserByEmail({ connection, email }) {
     const SQL = "SELECT * FROM `users` WHERE `email` = ?";
 

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -34,4 +34,6 @@ router.post(
   userController.checkNickname
 );
 
+router.get("/users/me", [loginRequired], userController.myProfile);
+
 export default router;

--- a/services/userService.js
+++ b/services/userService.js
@@ -4,6 +4,16 @@ import generateSalt from "../helpers/generateSalt.js";
 import userRepository from "../repositories/userRepository.js";
 
 const userService = {
+  async getUserProfile({ connection, userId }) {
+    const data = await userRepository.findUserById({ connection, userId });
+
+    return {
+      email: data.email,
+      nickname: data.nickname,
+      profileImageUrl: data.profile_image_url,
+    };
+  },
+
   async getUserByEmail({ connection, email }) {
     const data = await userRepository.findUserByEmail({ connection, email });
 


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- `findUserById` Repository 메서드를 구현했습니다.
- `getUserProfile` Service 메서드를 구현했습니다.(`password` 미 포함)
- route를 추가했습니다.(로그인 필요)

### PR Point
- `getUserProfile` 메서드에서 `data`는 camelCase로 변환되지 않은 row한 값이라서, `data.profile_image_url`와 같이 값을 가져와야 했습니다.
- `profileImageUrl` 값이 `null` 이더라도 값을 명시했습니다.

### 📸 스크린샷
- 로그인을 하지 않은 경우

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/1cee24ba-7f67-4f81-a30b-662041bcb078)|401 에러 반환|

- 로그인을 한 경우

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/fffe3900-96c1-41ce-9b6b-3e1f87451453)|프로필 데이터 반환|

closed #17 
