### PR TITLE
feat(roomList): 방 목록과 참여한 방 목록에 isJoined 필드 추가

### DIFF
--- a/controllers/roomController.js
+++ b/controllers/roomController.js
@@ -11,13 +11,14 @@ const roomController = {
       limit = DEFAULT_LIMIT,
       is_running: isRunning,
     } = req.query;
-    const { connection } = req;
+    const { connection, userId } = req;
 
     const rooms = await roomListService.getRooms({
       connection,
       page,
       limit,
       isRunning,
+      userId
     });
 
     return res.status(StatusCodes.OK).json(rooms);
@@ -64,6 +65,7 @@ const roomController = {
       page,
       limit,
       isRunning,
+      isMyRoom: true
     });
 
     return res.status(StatusCodes.OK).json(myRooms);

--- a/repositories/roomListRepository.js
+++ b/repositories/roomListRepository.js
@@ -1,4 +1,13 @@
 const roomListRepository = {
+  isJoinedFieldSQL: `
+    IF (
+      EXISTS (
+        SELECT * FROM user_rooms 
+        WHERE rooms.id = user_rooms.room_id AND 
+          user_rooms.user_id =?
+      ), TRUE, FALSE
+    ) AS isJoined,
+  `,
   async findDataAndTotalElements({ connection, SQL, values }) {
     const [data] = await connection.query(SQL, values);
     const [totalCount] = await connection.query("SELECT FOUND_ROWS()");
@@ -10,7 +19,7 @@ const roomListRepository = {
     };
   },
 
-  async findRooms({ connection, offset, limit, isRunning, userId }) {
+  async findRooms({ connection, offset, limit, isRunning, userId, isMyRoom }) {
     let SQL = `SELECT SQL_CALC_FOUND_ROWS
         rooms.id,
         room_title,
@@ -21,6 +30,7 @@ const roomListRepository = {
         short_break_time,
         long_break_time,
         is_running,
+        ${userId ? this.isJoinedFieldSQL : ""}
         max_participants,
         users.nickname AS ownerName,
         users.profile_image_url AS ownerProfileImageUrl,
@@ -33,6 +43,10 @@ const roomListRepository = {
     const values = [parseInt(limit), parseInt(offset)];
 
     if (userId) {
+      values.unshift(userId);
+    }
+
+    if (userId && isMyRoom) {
       SQL += "WHERE user_rooms.user_id = ? ";
       values.unshift(userId);
     }

--- a/repositories/roomListRepository.js
+++ b/repositories/roomListRepository.js
@@ -44,13 +44,12 @@ const roomListRepository = {
 
     if (userId) {
       values.unshift(userId);
+      if (isMyRoom) {
+        SQL += "WHERE user_rooms.user_id = ? ";
+        values.unshift(userId);
+      }
     }
-
-    if (userId && isMyRoom) {
-      SQL += "WHERE user_rooms.user_id = ? ";
-      values.unshift(userId);
-    }
-
+    
     SQL += "GROUP BY rooms.id ";
 
     if (isRunning === "false") {

--- a/routers/roomRouter.js
+++ b/routers/roomRouter.js
@@ -9,7 +9,7 @@ router.use(express.json());
 
 router.get(
   "/",
-  [...roomValidator.getAllRoomsValidator()],
+  [injectUserId, ...roomValidator.getAllRoomsValidator()],
   roomController.getRooms
 );
 

--- a/services/roomListService.js
+++ b/services/roomListService.js
@@ -1,7 +1,7 @@
 import roomListRepository from "../repositories/roomListRepository.js";
 
 const roomListService = {
-  async getRooms({ connection, page, limit, isRunning, userId }) {
+  async getRooms({ connection, page, limit, isRunning, userId, isMyRoom }) {
     const offset = (page - 1) * limit;
     const { data, totalElements } = await roomListRepository.findRooms({
       connection,
@@ -9,6 +9,7 @@ const roomListService = {
       limit,
       isRunning,
       userId,
+      isMyRoom,
     });
 
     return {


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 로그인 하지 않을 시에는 방 목록에 isJoined 필드가 보이지 않습니다.
- 로그인을 했을 경우 전체 방 목록 조회를 하면 isJoined 필드가 보입니다.
- 로그인을 했을 경우 참여한 방 목록 조회를 하면 isJoined 필드가 모두 true로 보입니다.

### PR Point
- isMyRoom 파라미터를 추가하여 전체 방 목록과 참여한 방 목록을 구분하였습니다.
- 방 목록 시에 isJoined 필드를 보이기 위해 `roomRouter`에서 `/rooms`에 `injectUserId` 미들웨어를 추가하였습니다.
- 확인 후 오류가 있다면 알려주세요! 

### 📸 스크린샷

| 사진 | 설명 |
|---|---|
|![비로그인시](https://github.com/Pogakco/BE/assets/80617446/7a087ead-68bf-44b6-b2a8-13bfb36acd9a) | 비 로그인 시 전체 방 목록에 isJoined 필드 보이지 않음 |
| ![로그인시](https://github.com/Pogakco/BE/assets/80617446/8bc2afd1-c77f-401d-8def-def8620945ed) | 로그인 시 전체 방 목록에 isJoined 필드 보임 |
| ![참여방](https://github.com/Pogakco/BE/assets/80617446/1ed62222-37b4-4f27-bd3c-a1e9fbedfc5d) | 참여 방 목록에 isJoined 필드 보임 |

closed #24 
