### PR TITLE
feat(timer): 타이머 소켓 추가기능 구현

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -8,6 +8,7 @@ export const SOCKET_DEFAULT_EVENTS = {
 };
 
 export const SOCKET_TIMER_EVENTS = {
+  SYNC_ALL_LINKED_USER_IDS: "sync-all-linked-user-ids",
   START_CYCLES: "start-cycles",
   SYNC_STARTED_AT: "sync-started-at",
   SYNC_IS_RUNNING: "sync-is-running",

--- a/repositories/userRoomRepository.js
+++ b/repositories/userRoomRepository.js
@@ -14,20 +14,17 @@ const userRoomRepository = {
     return data;
   },
 
-  async createOrUpdateActiveParticipants({ connection, roomId, userIds }) {
+  async updateParticipantsToActive({ connection, roomId, userIds }) {
     const SQL = `
-      INSERT INTO user_rooms
-        (user_id, room_id, is_active)
-      VALUES
-        ${userIds.map(() => "(?, ?, ?)").join(",")}
-      ON DUPLICATE KEY UPDATE
-        is_active = VALUES(is_active)
+      UPDATE user_rooms
+      SET 
+        is_active = true
+      WHERE 
+        room_id = ?
+        AND user_id IN (?)
     `;
 
-    await connection.query(
-      SQL,
-      userIds.flatMap((userId) => [userId, roomId, true])
-    );
+    await connection.query(SQL, [roomId, userIds]);
   },
 
   async updateAllParticipantsActiveStatus({ connection, roomId, isActive }) {

--- a/services/timerService.js
+++ b/services/timerService.js
@@ -11,7 +11,7 @@ const timerService = {
     });
 
     if (!isEmptyArray(userIds)) {
-      await userRoomRepository.createOrUpdateActiveParticipants({
+      await userRoomRepository.updateParticipantsToActive({
         connection,
         roomId,
         userIds,

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -2,14 +2,28 @@ import {
   SOCKET_DEFAULT_EVENTS,
   SOCKET_TIMER_EVENTS,
 } from "../../../constants.js";
+import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsFromNamespace.js";
+import getUserIdFromSocket from "../../helpers/getUserIdFromSocket.js";
 import getRoomIdFromNamespace from "../helpers/getRoomIdFromNamespace.js";
 import onRoomDetailDisconnect from "./onRoomDetailDisconnect.js";
 import onStartCycles from "./onStartCycles.js";
 
 const onConnection = (socket) => {
   const roomId = getRoomIdFromNamespace(socket.nsp);
+  const userId = getUserIdFromSocket(socket);
 
   socket.join(roomId);
+
+  // 로그인 한 유저일 때만 클라이언트에 동기화
+  if (userId) {
+    const roomDetailNamespace = socket.nsp;
+    roomDetailNamespace
+      .to(roomId)
+      .emit(
+        SOCKET_TIMER_EVENTS.SYNC_ALL_LINKED_USER_IDS,
+        getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
+      );
+  }
 
   console.log("A user connected to room:", roomId);
 

--- a/socket/room-detail/handlers/onRoomDetailDisconnect.js
+++ b/socket/room-detail/handlers/onRoomDetailDisconnect.js
@@ -1,5 +1,7 @@
+import { SOCKET_TIMER_EVENTS } from "../../../constants.js";
 import pool from "../../../db/pool.js";
 import roomService from "../../../services/roomService.js";
+import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsFromNamespace.js";
 import getUserIdFromSocket from "../../helpers/getUserIdFromSocket.js";
 import getRoomIdFromNamespace from "../helpers/getRoomIdFromNamespace.js";
 
@@ -12,6 +14,16 @@ const onRoomDetailDisconnect = async (socket) => {
   socket.leave(roomId);
 
   if (userId) {
+    // 소켓에 연결된 유저 아이디 목록 클라이언트에 동기화
+    const roomDetailNamespace = socket.nsp;
+    roomDetailNamespace
+      .to(roomId)
+      .emit(
+        SOCKET_TIMER_EVENTS.SYNC_ALL_LINKED_USER_IDS,
+        getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
+      );
+
+    // inactive 상태로 DB Update
     await roomService.inactiveParticipant({ connection, roomId, userId });
   }
 

--- a/socket/room-detail/helpers/calculateMs.js
+++ b/socket/room-detail/helpers/calculateMs.js
@@ -10,7 +10,7 @@ const calculateLongBreakTimeMs = (longBreakTime) => {
   return longBreakTime * MINUTE_MS;
 };
 
-export const calculateTimerTotalMs = ({
+const calculateTimerTotalMs = ({
   focusTime,
   shortBreakTime,
   totalCycles,
@@ -19,5 +19,23 @@ export const calculateTimerTotalMs = ({
   return (
     calculateOnePomodoroMs({ focusTime, shortBreakTime }) * totalCycles +
     calculateLongBreakTimeMs(longBreakTime)
+  );
+};
+
+export const calculateTimerTotalMsWithDelay = ({
+  focusTime,
+  shortBreakTime,
+  totalCycles,
+  longBreakTime,
+}) => {
+  const delayMs = 5 * SECOND_MS; // 각 클라이언트들의 타이머 종료를 기다리고, 맞지 않는 싱크를 보정하기 위해 사용되는 값
+
+  return (
+    calculateTimerTotalMs({
+      focusTime,
+      shortBreakTime,
+      totalCycles,
+      longBreakTime,
+    }) + delayMs
   );
 };

--- a/socket/room-detail/helpers/getFinishCyclesTimeout.js
+++ b/socket/room-detail/helpers/getFinishCyclesTimeout.js
@@ -1,7 +1,7 @@
 import camelcaseKeys from "camelcase-keys";
 import { SOCKET_TIMER_EVENTS } from "../../../constants.js";
 import timerService from "../../../services/timerService.js";
-import { calculateTimerTotalMs } from "./calculateMs.js";
+import { calculateTimerTotalMsWithDelay } from "./calculateMs.js";
 import getRoomIdFromNamespace from "./getRoomIdFromNamespace.js";
 
 const finishCyclesTimeoutGetter = ({ connection, socket, roomInfo }) => {
@@ -48,7 +48,7 @@ const finishCyclesTimeoutGetter = ({ connection, socket, roomInfo }) => {
           clearTimeout(finishCyclesTimeout);
           reject(error);
         }
-      }, calculateTimerTotalMs({ focusTime, shortBreakTime, totalCycles, longBreakTime }));
+      }, calculateTimerTotalMsWithDelay({ focusTime, shortBreakTime, totalCycles, longBreakTime }));
     });
 
   return { clearFinishCyclesTimeout, startFinishCyclesTimeout };


### PR DESCRIPTION
# Pull Request
## 작업한 내용
### 1. 시작시 유저 방 참가시키는 로직을 변경 했습니다.
- **이전 로직**: 방장이 시작 버튼을 누르면, 소켓 연결이 되어 있으면서 로그인 한 모든 유저를 `user_rooms` 테이블에 `is_active = true`로 데이터를 Insert 한다. 이미 `user_rooms`에 데이터가 있을 경우에는 `is_active = true`로 Update 한다.
- **변경된 로직**: 방장이 시작 버튼을 누르면, 소켓 연결이 되어 있으면서 `user_rooms`의 `room_id`가 현재 방인 데이터들의 `is_active` 상태를 `true`로 Update 한다.
  - `user_rooms` 데이터를 Insert하는 작업, 즉 방에 참여하는 로직은 방 참여하기 버튼을 눌렀을 경우 처리한다.

<br/>

### 2. 타이머가 전부 끝났을 경우 `sync-is-running`과 `sync-current-cycles`을 동기화 하는 작업 등을 5초 뒤에 수행하도록 변경 했습니다.
- 중간에 방에 들어온 유저와 싱크를 맞추기 위해 5초의 딜레이 시간을 추가했습니다.

<br/>

### 3. 시작을 기다리고 있는 유저들을 나타내기 위해 `sync-all-linked-user-ids` 이벤트를 추가했습니다.

<br/><br/>

## PR Point
- 기능이 변경한 대로 작동하는지 확인 부탁드립니다!

### 📸 스크린샷

- 방에 참여하지 않은 로그인한 유저는 타이머가 시작되어도 `active` 상태로 변하지 않음

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/741f4cfe-d156-425b-9156-e36701a10822)|방에 참여한 유저만 `active` 상태로 변하고 뽀모도로 카운트의 대상이 됩니다.|

- 방 참여 여부를 떠나서 연결된 모든 유저의 id 배열을 프론트와 동기화

|사진|설명|
|---|---|
|![image](https://github.com/Pogakco/BE/assets/123533586/a5ddaf14-1a13-437c-991f-6fe5ae218e7d)|타이머 시작 대기 유저를 나타내는데 사용할 수 있습니다.|

closed #25 
