### PR TITLE
feat(user): 비밀번호 확인 api 구현

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -108,6 +108,25 @@ const userController = {
 
     return res.status(StatusCodes.OK).json(profile);
   }),
+
+  confirmPassword: errorHandler(async (req, res) => {
+    const { connection, userId } = req;
+    const { password } = req.body;
+
+    const isValidPassword = await userService.validatePassword({
+      connection,
+      userId,
+      password,
+    });
+
+    if (!isValidPassword) {
+      return res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "비밀번호가 틀렸습니다." });
+    }
+
+    return res.status(StatusCodes.NO_CONTENT).end();
+  }),
 };
 
 export default userController;

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -38,7 +38,7 @@ router.get("/users/me", [loginRequired], userController.myProfile);
 
 router.post(
   "/users/me/confirm-password",
-  [loginRequired],
+  [loginRequired, ...userValidator.getCheckPasswordValidator()],
   userController.confirmPassword
 );
 

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -36,4 +36,10 @@ router.post(
 
 router.get("/users/me", [loginRequired], userController.myProfile);
 
+router.post(
+  "/users/me/confirm-password",
+  [loginRequired],
+  userController.confirmPassword
+);
+
 export default router;

--- a/services/userService.js
+++ b/services/userService.js
@@ -85,6 +85,16 @@ const userService = {
 
     return accessToken;
   },
+
+  async validatePassword({ connection, userId, password }) {
+    const userData = await userRepository.findUserById({ connection, userId });
+    if (!userData) {
+      return false;
+    }
+
+    const hashedPassword = convertHashedPassword(password, userData.salt);
+    return hashedPassword === userData.password;
+  },
 };
 
 export default userService;

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -68,6 +68,10 @@ const userValidator = {
   getCheckNicknameValidator() {
     return createValidator(createNicknameChain);
   },
+
+  getCheckPasswordValidator() {
+    return createValidator(createLoginPasswordChain);
+  },
 };
 
 export default userValidator;


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 비밀번호를 확인하는 API를 추가했습니다.
- 로그인하지 않은 경우 에러 처리를 추가했습니다.
- 비밀번호가 맞지 않는 경우 에러 처리를 추가했습니다.
- 비밀번호를 입력하지 않은 경우 에러 처리를 추가했습니다.

### PR Point
- 비밀번호 확인 시 정규표현식 유효성 검사가 필요 없다고 판단했습니다.
  - 따라서 비밀번호를 입력하지 않은 경우에만 유효성 검사를 적용했습니다.
- 혹시 추가적으로 필요한 에러처리가 있다면 알려주세요!!

### 📸 스크린샷

|사진|설명|
|---|---|
| ![비로그인](https://github.com/Pogakco/BE/assets/80617446/2634e763-b908-4c84-a96d-e5938765c20c) | 로그인하지 않았을 경우 |
| ![비밀번호 미 입력](https://github.com/Pogakco/BE/assets/80617446/402ff6fe-c30f-450c-80a6-3b24caa47089) | 비밀번호 미 입력시 |
| ![비밀번호틀림](https://github.com/Pogakco/BE/assets/80617446/bfc45e25-20fd-4482-a6ed-7fdc2ca5af52) | 비밀번호 오류 |
| ![비밀번호맞음](https://github.com/Pogakco/BE/assets/80617446/f0bbf6cc-939a-4385-b6bd-14970146d6be) | 비밀번호 맞음 |


closed #이슈번호
