### PR TITLE
feat(timer-socket): 방 삭제하기 소켓 이벤트 구현

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -14,12 +14,16 @@ export const SOCKET_TIMER_EVENTS = {
   SYNC_IS_RUNNING: "sync-is-running",
   SYNC_ALL_PARTICIPANTS: "sync-all-participants",
   SYNC_CURRENT_CYCLES: "sync-current-cycles",
+  ROOM_DELETED: "room-deleted",
+  DELETE_ROOM: "delete-room",
   ERROR: "timer-error",
 };
 
 export const SOCKET_TIMER_ERRORS = {
-  IS_NOT_OWNER: "방장만 타이머를 시작할 수 있습니다.",
+  IS_NOT_OWNER: "방장 권한이 없습니다.",
   INTERNAL_SERVER_ERROR: "서버 오류가 발생했습니다.",
+  NOT_FOUND_ROOM: "존재하지 않는 방입니다.",
+  PROHIBIT_DELETE_RUNNING_ROOM: "집중 중인 방은 삭제할 수 없습니다.",
 };
 
 export const DEFAULT_PAGE = 1;

--- a/constants.js
+++ b/constants.js
@@ -18,8 +18,8 @@ export const SOCKET_TIMER_EVENTS = {
 };
 
 export const SOCKET_TIMER_ERRORS = {
-  DEFAULT: "타이머 소켓에서 오류가 발생했습니다.",
   IS_NOT_OWNER: "방장만 타이머를 시작할 수 있습니다.",
+  INTERNAL_SERVER_ERROR: "서버 오류가 발생했습니다.",
 };
 
 export const DEFAULT_PAGE = 1;

--- a/controllers/roomController.js
+++ b/controllers/roomController.js
@@ -176,27 +176,6 @@ const roomController = {
     await roomService.leaveRoom({ connection, roomId, userId });
     return res.status(StatusCodes.NO_CONTENT).end();
   }),
-
-  deleteRoom: errorHandler(async (req, res) => {
-    const { connection, userId } = req;
-    const roomId = parseInt(req.params.id);
-
-    const room = await roomService.getRoomById({ connection, roomId });
-    if (!room) {
-      return res
-        .status(StatusCodes.NOT_FOUND)
-        .json({ message: "존재하지 않는 방입니다." });
-    }
-
-    if (room.ownerId !== userId) {
-      return res
-        .status(StatusCodes.FORBIDDEN)
-        .json({ message: "권한이 없습니다." });
-    }
-
-    await roomService.deleteRoom({ connection, roomId });
-    return res.status(StatusCodes.NO_CONTENT).end();
-  }),
 };
 
 export default roomController;

--- a/routers/roomRouter.js
+++ b/routers/roomRouter.js
@@ -31,12 +31,6 @@ router.get(
   roomController.getRoomDetail
 );
 
-router.delete(
-  "/:id",
-  [loginRequired, ...roomValidator.getRoomDetailValidator()],
-  roomController.deleteRoom
-);
-
 router.post(
   "/:id/join",
   [loginRequired, ...roomValidator.getRoomDetailValidator()],

--- a/services/roomService.js
+++ b/services/roomService.js
@@ -1,3 +1,4 @@
+import pool from "../db/pool.js";
 import roomRepository from "../repositories/roomRepository.js";
 import timerRepository from "../repositories/timerRepository.js";
 import userRoomRepository from "../repositories/userRoomRepository.js";
@@ -114,8 +115,16 @@ const roomService = {
     await userRoomRepository.removeUserFromRoom({ connection, userId, roomId });
   },
 
-  async deleteRoom({ connection, roomId }) {
-    await roomRepository.deleteRoom({ connection, roomId });
+  async deleteRoom({ roomId }) {
+    const connection = await pool.getConnection();
+
+    try {
+      await roomRepository.deleteRoom({ connection, roomId });
+    } catch (error) {
+      throw error;
+    } finally {
+      connection.release();
+    }
   },
 };
 

--- a/socket/room-detail/handlers/onDeleteRoom.js
+++ b/socket/room-detail/handlers/onDeleteRoom.js
@@ -1,0 +1,60 @@
+import {
+  SOCKET_TIMER_ERRORS,
+  SOCKET_TIMER_EVENTS,
+} from "../../../constants.js";
+import roomService from "../../../services/roomService.js";
+import getUserIdFromSocket from "../../helpers/getUserIdFromSocket.js";
+import getRoomIdFromNamespace from "../helpers/getRoomIdFromNamespace.js";
+import getRoomInfoSafety from "../helpers/getRoomInfoSafety.js";
+
+const onDeleteRoom = async (socket) => {
+  const { roomInfo, isErrorGetRoomInfo } = await getRoomInfoSafety({
+    socket,
+  });
+
+  if (isErrorGetRoomInfo) {
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
+    });
+    return;
+  }
+
+  if (!roomInfo) {
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.NOT_FOUND_ROOM,
+    });
+    return;
+  }
+
+  const userId = getUserIdFromSocket(socket);
+  if (roomInfo.ownerId !== userId) {
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.IS_NOT_OWNER,
+    });
+    return;
+  }
+
+  if (roomInfo.isRunning) {
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.PROHIBIT_DELETE_RUNNING_ROOM,
+    });
+    return;
+  }
+
+  try {
+    const roomDetailNamespace = socket.nsp;
+    const roomId = getRoomIdFromNamespace(roomDetailNamespace);
+
+    await roomService.deleteRoom({ roomId });
+
+    roomDetailNamespace.to(roomId).emit(SOCKET_TIMER_EVENTS.ROOM_DELETED);
+  } catch (error) {
+    console.log(error);
+
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
+    });
+  }
+};
+
+export default onDeleteRoom;

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -5,6 +5,7 @@ import {
 import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsFromNamespace.js";
 import getUserIdFromSocket from "../../helpers/getUserIdFromSocket.js";
 import getRoomIdFromNamespace from "../helpers/getRoomIdFromNamespace.js";
+import onDeleteRoom from "./onDeleteRoom.js";
 import onRoomDetailDisconnect from "./onRoomDetailDisconnect.js";
 import onStartCycles from "./onStartCycles.js";
 
@@ -28,7 +29,7 @@ const onConnection = (socket) => {
   console.log("A user connected to room:", roomId);
 
   socket.on(SOCKET_TIMER_EVENTS.START_CYCLES, () => onStartCycles(socket));
-
+  socket.on(SOCKET_TIMER_EVENTS.DELETE_ROOM, () => onDeleteRoom(socket));
   socket.on(SOCKET_DEFAULT_EVENTS.DISCONNECT, () =>
     onRoomDetailDisconnect(socket)
   );

--- a/socket/room-detail/handlers/onStartCycles.js
+++ b/socket/room-detail/handlers/onStartCycles.js
@@ -51,7 +51,7 @@ const onStartCycles = async (socket) => {
     clearFinishCyclesTimeout();
 
     socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
-      message: SOCKET_TIMER_ERRORS.DEFAULT,
+      message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
     });
     console.error(error);
 

--- a/socket/room-detail/handlers/onStartCycles.js
+++ b/socket/room-detail/handlers/onStartCycles.js
@@ -15,7 +15,6 @@ const onStartCycles = async (socket) => {
   const connection = await pool.getConnection();
 
   const { roomInfo, isErrorGetRoomInfo } = await getRoomInfoSafety({
-    connection,
     socket,
   });
   if (isErrorGetRoomInfo) {

--- a/socket/room-detail/helpers/getRoomInfoSafety.js
+++ b/socket/room-detail/helpers/getRoomInfoSafety.js
@@ -6,7 +6,9 @@ import {
 import roomService from "../../../services/roomService.js";
 import getRoomIdFromNamespace from "./getRoomIdFromNamespace.js";
 
-const getRoomInfoSafety = async ({ connection, socket }) => {
+const getRoomInfoSafety = async ({ socket }) => {
+  const connection = await pool.getConnection();
+
   let roomInfo = null;
   let isErrorGetRoomInfo = false;
 
@@ -23,8 +25,9 @@ const getRoomInfoSafety = async ({ connection, socket }) => {
       message: SOCKET_TIMER_ERRORS.DEFAULT,
     });
     console.error(error);
-    connection.release();
     isErrorGetRoomInfo = true;
+  } finally {
+    connection.release();
   }
 
   return { roomInfo, isErrorGetRoomInfo };

--- a/socket/room-detail/helpers/getRoomInfoSafety.js
+++ b/socket/room-detail/helpers/getRoomInfoSafety.js
@@ -3,6 +3,7 @@ import {
   SOCKET_TIMER_ERRORS,
   SOCKET_TIMER_EVENTS,
 } from "../../../constants.js";
+import pool from "../../../db/pool.js";
 import roomService from "../../../services/roomService.js";
 import getRoomIdFromNamespace from "./getRoomIdFromNamespace.js";
 
@@ -22,7 +23,7 @@ const getRoomInfoSafety = async ({ socket }) => {
     roomInfo = camelcaseKeys(data);
   } catch (error) {
     socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
-      message: SOCKET_TIMER_ERRORS.DEFAULT,
+      message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
     });
     console.error(error);
     isErrorGetRoomInfo = true;


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 기존 방 삭제하기 API를 제거하고 요구사항이 추가된 방 삭제하기 소켓 이벤트를 구현 했습니다.

### PR Point
- 소켓 이벤트를 통해 방이 삭제됐음을 전파해야 돼서, 기존의 방 삭제하기 API를 제거하고 소켓 이벤트로 재구현 했습니다.
- `delete-room` 이벤트를 요청 받으면 방 삭제하는 로직을 수행합니다.
- `isRunning = true`인 방은 삭제하지 못하도록 예외 처리를 추가 했습니다.
- `room-deleted` 이벤트를 통해 방이 삭제됐음을 클라이언트에 전파합니다. 클라이언트에서 해당 이벤트를 전파 받으면 메인 페이지로 이동시킵니다.

### 📸 스크린샷
- 방장이 아닐 때 방 삭제하기 버튼 클릭시 에러 메세지 반환

![image](https://github.com/user-attachments/assets/e9488534-a822-4622-b3f0-3857df45ba43)

- 방장이 방을 삭제하면, `room-deleted` 이벤트를 전파받아서 프론트에서 메인 화면으로 redirect 처리

![image](https://github.com/user-attachments/assets/68b0e076-29f8-4e7f-8c67-f9cef1535721)

![image](https://github.com/user-attachments/assets/51ca7a59-08d4-4280-9188-a48fe882846c)

방이 삭제되고 메인화면으로 이동한 것을 확인할 수 있습니다.

closed #55 
