### PR TITLE
fix(sql): Left Join에 Where절을 사용하면서 Count문이 잘 작동하지 않는 문제를 서브 쿼리를 사용하여 해결

### DIFF
--- a/repositories/roomListRepository.js
+++ b/repositories/roomListRepository.js
@@ -34,7 +34,7 @@ const roomListRepository = {
         max_participants,
         users.nickname AS ownerName,
         users.profile_image_url AS ownerProfileImageUrl,
-        COUNT(user_rooms.user_id) AS currentParticipants
+        (SELECT COUNT(*) FROM user_rooms WHERE user_rooms.room_id = rooms.id) AS currentParticipants
       FROM rooms
       LEFT JOIN timers ON rooms.timer_id = timers.id
       LEFT JOIN users ON rooms.owner_id = users.id


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- Left Join에 Where절을 사용하면서 Count문이 잘 작동하지 않는 문제를 서브 쿼리를 사용하여 해결 했습니다.

### PR Point
- `isMyRoom`일 경우 `"WHERE user_rooms.user_id = ? "` 이 추가 되는데, 이 때 기존의 `Count(...)` 부분이 정상적으로 작동하지 않아 잘못된 Count 값을 반환 했습니다. 이를 서브 쿼리를 사용 하여 문제를 해결 했습니다.

closed #61
