### PR TITLE
feat(timer): 소켓을 통해 연동되는 참가자 정보를 API와 통일

### DIFF
--- a/services/timerService.js
+++ b/services/timerService.js
@@ -3,6 +3,7 @@ import roomRepository from "../repositories/roomRepository.js";
 import timerRepository from "../repositories/timerRepository.js";
 import userRoomRepository from "../repositories/userRoomRepository.js";
 import isEmptyArray from "../utils/isEmptyArray.js";
+import roomService from "./roomService.js";
 
 const timerService = {
   async startTimer({ roomId, userIds }) {
@@ -54,12 +55,10 @@ const timerService = {
         roomId,
       });
 
-      const allParticipants = await userRoomRepository.findParticipants({
-        connection,
-        roomId,
-      });
+      const roomUsersAndActiveCount =
+        await roomService.getRoomUsersAndActiveCount({ roomId });
 
-      return { allParticipants };
+      return { roomUsersAndActiveCount };
     } catch (error) {
       throw error;
     } finally {
@@ -90,12 +89,10 @@ const timerService = {
         roomId,
       });
 
-      const allParticipants = await userRoomRepository.findParticipants({
-        connection,
-        roomId,
-      });
+      const roomUsersAndActiveCount =
+        await roomService.getRoomUsersAndActiveCount({ roomId });
 
-      return { increasedCurrentCycles, allParticipants };
+      return { increasedCurrentCycles, roomUsersAndActiveCount };
     } catch (error) {
       throw error;
     } finally {

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -28,12 +28,12 @@ const onConnection = async (socket) => {
       );
 
     try {
-      const { users: allParticipants } =
+      const roomUsersAndActiveCount =
         await roomService.getRoomUsersAndActiveCount({ roomId });
 
       roomDetailNamespace
         .to(roomId)
-        .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, allParticipants);
+        .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, roomUsersAndActiveCount);
     } catch (error) {
       socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
         message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,

--- a/socket/room-detail/handlers/onRoomDetailDisconnect.js
+++ b/socket/room-detail/handlers/onRoomDetailDisconnect.js
@@ -2,7 +2,6 @@ import {
   SOCKET_TIMER_ERRORS,
   SOCKET_TIMER_EVENTS,
 } from "../../../constants.js";
-import pool from "../../../db/pool.js";
 import roomService from "../../../services/roomService.js";
 import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsFromNamespace.js";
 import getUserIdFromSocket from "../../helpers/getUserIdFromSocket.js";
@@ -29,12 +28,15 @@ const onRoomDetailDisconnect = async (socket) => {
 
     // 참가자 목록 클라이언트에 동기화
     try {
-      const { users: allParticipants } =
+      const roomUsersAndActiveCount =
         await roomService.getRoomUsersAndActiveCount({ roomId });
 
       roomDetailNamespace
         .to(roomId)
-        .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, allParticipants);
+        .emit(
+          SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS,
+          roomUsersAndActiveCount
+        );
     } catch (error) {
       socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
         message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,

--- a/socket/room-detail/helpers/getFinishCyclesTimeout.js
+++ b/socket/room-detail/helpers/getFinishCyclesTimeout.js
@@ -1,4 +1,3 @@
-import camelcaseKeys from "camelcase-keys";
 import { SOCKET_TIMER_EVENTS } from "../../../constants.js";
 import timerService from "../../../services/timerService.js";
 import { calculateTimerTotalMsWithDelay } from "./calculateMs.js";
@@ -31,7 +30,7 @@ const finishCyclesTimeoutGetter = ({ socket, roomInfo }) => {
             .to(roomId)
             .emit(SOCKET_TIMER_EVENTS.SYNC_CURRENT_CYCLES, 0);
 
-          const { allParticipants } = await timerService.finishTimer({
+          const { roomUsersAndActiveCount } = await timerService.finishTimer({
             roomId,
           });
 
@@ -39,7 +38,7 @@ const finishCyclesTimeoutGetter = ({ socket, roomInfo }) => {
             .to(roomId)
             .emit(
               SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS,
-              camelcaseKeys(allParticipants)
+              roomUsersAndActiveCount
             );
 
           resolve();

--- a/socket/room-detail/helpers/getPomodoroInterval.js
+++ b/socket/room-detail/helpers/getPomodoroInterval.js
@@ -1,4 +1,3 @@
-import camelcaseKeys from "camelcase-keys";
 import { SOCKET_TIMER_EVENTS } from "../../../constants.js";
 import timerService from "../../../services/timerService.js";
 import { calculateOnePomodoroMs } from "./calculateMs.js";
@@ -25,14 +24,14 @@ const getPomodoroInterval = ({ socket, roomInfo }) => {
         try {
           console.log(pomodoroCount + 1, "뽀모도로 끝");
 
-          const { increasedCurrentCycles, allParticipants } =
+          const { increasedCurrentCycles, roomUsersAndActiveCount } =
             await timerService.finishPomodoro({ roomId });
 
           roomDetailNamespace
             .to(roomId)
             .emit(
               SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS,
-              camelcaseKeys(allParticipants)
+              roomUsersAndActiveCount
             );
           roomDetailNamespace
             .to(roomId)


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 소켓에 연동된 참가자 정보 데이터도 `{ users, activeParticipants }` 형태로 통일 했습니다.

### PR Point
- 타이머 작동이 잘 되는지, DB에 pomodoroCount값이 잘 증가하는지 등 확인 부탁드립니다!

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/23c2f8bb-a0a0-4341-81d8-ab968fd1bb43)

closed #60
