### PR TITLE
fix(socket): 타이머 소켓에 연결될 때 연결된 유저 정보, 참여자 정보 값이 비로그인 유저도 동기화 되도록 수정

### DIFF
--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -25,21 +25,18 @@ const onConnection = async (socket) => {
       getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
     );
 
-  // 로그인 한 유저일 때만 클라이언트에 동기화
-  if (userId) {
-    try {
-      const { users: allParticipants } =
-        await roomService.getRoomUsersAndActiveCount({ roomId });
+  try {
+    const { users: allParticipants } =
+      await roomService.getRoomUsersAndActiveCount({ roomId });
 
-      roomDetailNamespace
-        .to(roomId)
-        .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, allParticipants);
-    } catch (error) {
-      socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
-        message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
-      });
-      return;
-    }
+    roomDetailNamespace
+      .to(roomId)
+      .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, allParticipants);
+  } catch (error) {
+    socket.emit(SOCKET_TIMER_EVENTS.ERROR, {
+      message: SOCKET_TIMER_ERRORS.INTERNAL_SERVER_ERROR,
+    });
+    return;
   }
 
   console.log("A user connected to room:", roomId);

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -17,16 +17,16 @@ const onConnection = async (socket) => {
 
   socket.join(roomId);
 
+  const roomDetailNamespace = socket.nsp;
+  roomDetailNamespace
+    .to(roomId)
+    .emit(
+      SOCKET_TIMER_EVENTS.SYNC_ALL_LINKED_USER_IDS,
+      getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
+    );
+
   // 로그인 한 유저일 때만 클라이언트에 동기화
   if (userId) {
-    const roomDetailNamespace = socket.nsp;
-    roomDetailNamespace
-      .to(roomId)
-      .emit(
-        SOCKET_TIMER_EVENTS.SYNC_ALL_LINKED_USER_IDS,
-        getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
-      );
-
     try {
       const { users: allParticipants } =
         await roomService.getRoomUsersAndActiveCount({ roomId });


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 비로그인한 유저가 방에 들어갔을 때에는 `syncedAllLinkedUserIds` 값이 연동되지 않는 버그를 수정 했습니다. 그리고 `syncedAllParticipants` 값도 프론트 요구사항에 맞춰 비로그인 유저도 연동 되도록 변경 했습니다.

### PR Point
- 프론트 코드도 PR이 올라가 있는데, 반영 된다면 `main` 브랜치에서 테스트 하시고 아니면 [Fix/RoomUserAPI](https://github.com/Pogakco/FE/tree/Fix/RoomUserAPI) 체크아웃 하셔서 테스트 해주시면 됩니다!

### 📸 스크린샷
- 비 로그인 유저가 방에 참여 했을 경우

![image](https://github.com/user-attachments/assets/b5af2cfc-7273-470d-9237-bf83d82f06a8)


closed #72 
