### PR TITLE
feat(timer): 운영 환경에서 타이머가 분 단위로 작동하게 변경

### DIFF
--- a/socket/room-detail/helpers/calculateMs.js
+++ b/socket/room-detail/helpers/calculateMs.js
@@ -1,11 +1,14 @@
-import { SECOND_MS } from "../../../constants.js";
+import { IS_DEV_MODE, MINUTE_MS, SECOND_MS } from "../../../constants.js";
+
+// 단위 시간을 개발(1초), 운영(1분) 환경 별로 다르게 설정
+const TIME_UNIT = IS_DEV_MODE ? SECOND_MS : MINUTE_MS;
 
 export const calculateOnePomodoroMs = ({ focusTime, shortBreakTime }) => {
-  return (focusTime + shortBreakTime) * SECOND_MS; // TODO: 타이머 개발단계 마무리 되면 MINUTE_MS으로 변경
+  return (focusTime + shortBreakTime) * TIME_UNIT;
 };
 
 const calculateLongBreakTimeMs = (longBreakTime) => {
-  return longBreakTime * SECOND_MS; // TODO: 타이머 개발단계 마무리 되면 MINUTE_MS으로 변경
+  return longBreakTime * TIME_UNIT;
 };
 
 const calculateTimerTotalMs = ({


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 현재 디버깅을 위해 시간 단위가 '초'로 설정 되어있는데, 로컬 환경에서는 동일하게 '초'로 작동하고 운영 환경에서는 '분'으로 작동하도록 적용 했습니다.

### PR Point
- 아래와 같이 DB 설정을 임시로 변경 해주세요.
  ```js
  export const poolOption = {
    host: "localhost",
    ...
  }
  ```
- `NODE_ENV=production node app.js` 커맨드를 통해 Express 서버를 실행해 주세요.
- DB에서 집중시간, 휴식시간, 대휴식시간을 1로 설정해도 3분의 긴 시간동안 테스트를 해야 합니다.. 2분(집중시간+휴식시간) 후에 `pomodoroCount` 값이 증가하는지 확인 해주세요.

closed #74
