### PR TITLE
feat(timer-socket): 타이머 시작시점에도 참여중인 유저정보 동기화 되도록 변경, 딜레이 시간 2초로 축소

### DIFF
--- a/socket/room-detail/helpers/calculateMs.js
+++ b/socket/room-detail/helpers/calculateMs.js
@@ -26,7 +26,7 @@ export const calculateTimerTotalMsWithDelay = ({
   totalCycles,
   longBreakTime,
 }) => {
-  const delayMs = 5 * SECOND_MS; // 각 클라이언트들의 타이머 종료를 기다리고, 맞지 않는 싱크를 보정하기 위해 사용되는 값
+  const delayMs = 2 * SECOND_MS; // 각 클라이언트들의 타이머 종료를 기다리고, 맞지 않는 싱크를 보정하기 위해 사용되는 값
 
   return (
     calculateTimerTotalMs({

--- a/socket/room-detail/helpers/startTimer.js
+++ b/socket/room-detail/helpers/startTimer.js
@@ -1,4 +1,5 @@
 import { SOCKET_TIMER_EVENTS } from "../../../constants.js";
+import roomService from "../../../services/roomService.js";
 import timerService from "../../../services/timerService.js";
 import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsFromNamespace.js";
 import getRoomIdFromNamespace from "./getRoomIdFromNamespace.js";
@@ -13,10 +14,15 @@ const startTimer = async ({ socket }) => {
     roomId,
     userIds: allLinkedUserIds,
   });
+  const { users: allParticipants } =
+    await roomService.getRoomUsersAndActiveCount({ roomId });
 
   roomDetailNamespace
     .to(roomId)
     .emit(SOCKET_TIMER_EVENTS.SYNC_STARTED_AT, startedAt);
+  roomDetailNamespace
+    .to(roomId)
+    .emit(SOCKET_TIMER_EVENTS.SYNC_ALL_PARTICIPANTS, allParticipants);
   roomDetailNamespace
     .to(roomId)
     .emit(SOCKET_TIMER_EVENTS.SYNC_IS_RUNNING, true);


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- `active` 상태의 유저를 🔥 이모지로 구분하는데, 타이머가 시작하는 시점에는 유저정보가 동기화 되지 않아서 한 뽀모도로가 끝나야 `active` 상태인 유저가 업데이트 되는 문제를 시작시점에도 동기화 하도록 변경해서 문제를 해결 했습니다.
- 딜레이시간을 2초로 줄여서 휴식상태로 자연스럽게 넘어가도록 변경 했습니다.

### PR Point
- 타이머 시작시 🔥 이모지가 `active` 유저 옆에 생기는지 확인해 주세요.
- 소켓에서 연결이 끊어졌을 때 🔥 이모지가 사라지는지 확인해 주세요.
- 모든 타이머가 종료 되었을때 자연스럽게 휴식 상태로 전환 되는지 확인해 주세요.

### 📸 스크린샷
- 타이머 시작한 직후

![image](https://github.com/user-attachments/assets/fed303d7-8eac-4085-a8a9-197b502b5c22)


- 타이머 도중 나갔다 들어올 경우

![image](https://github.com/user-attachments/assets/70ceafc4-e6ff-4bd6-b127-d0ae602e0ec4)


closed #81 
