### PR TITLE
feat(timer-socket): 타이머 소켓에 연결 될 때 isRunning 상태를 동기화 하도록 변경

### DIFF
--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -19,6 +19,7 @@ const onConnection = async (socket) => {
   const roomId = getRoomIdFromNamespace(roomDetailNamespace);
   socket.join(roomId);
 
+  // 모든 로그인한 유저 정보 동기화
   roomDetailNamespace
     .to(roomId)
     .emit(
@@ -26,6 +27,7 @@ const onConnection = async (socket) => {
       getAllLinkedUserIdsFromNamespace(roomDetailNamespace)
     );
 
+  // 방의 타이머 진행 상태 동기화
   const { roomInfo, isErrorGetRoomInfo } = await getRoomInfoSafety({
     socket,
   });
@@ -39,6 +41,7 @@ const onConnection = async (socket) => {
     .to(roomId)
     .emit(SOCKET_TIMER_EVENTS.SYNC_IS_RUNNING, roomInfo.isRunning);
 
+  // 참가자 정보 동기화
   try {
     const { users: allParticipants } =
       await roomService.getRoomUsersAndActiveCount({ roomId });
@@ -55,6 +58,7 @@ const onConnection = async (socket) => {
 
   console.log("A user connected to room:", roomId);
 
+  // 리스닝 이벤트 등록
   socket.on(SOCKET_TIMER_EVENTS.START_CYCLES, () => onStartCycles(socket));
   socket.on(SOCKET_TIMER_EVENTS.DELETE_ROOM, () => onDeleteRoom(socket));
   socket.on(SOCKET_DEFAULT_EVENTS.DISCONNECT, () =>

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -14,11 +14,10 @@ import onStartCycles from "./onStartCycles.js";
 const onConnection = async (socket) => {
   registerRoomDetailEventsInterceptor(socket);
 
-  const roomId = getRoomIdFromNamespace(socket.nsp);
-
+  const roomDetailNamespace = socket.nsp;
+  const roomId = getRoomIdFromNamespace(roomDetailNamespace);
   socket.join(roomId);
 
-  const roomDetailNamespace = socket.nsp;
   roomDetailNamespace
     .to(roomId)
     .emit(


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- `onConnection` 핸들러에 `sync-is-running` 이벤트 전파를  추가 했습니다.
- 프론트엔드에서 중간에 관전하는 유저의 경우 isRunning 값이 연동 안되는 문제를 해결하기 위해 기능을 추가 했습니다.

### PR Point
- `onRoomDetailConnection` 에서 DB 정보를 가져오는 부분이 어떤건 helper 함수, 어떤건 try/catch 내에서 Service 메서드를 사용하는 식으로 되어 있어서 추후 리펙터링 할 때에는 공통 에러 핸들러를 소켓에 적용시키고 Service 메서드만 사용하는 식으로 변경하면 좋겠다는 생각이 들었습니다.

### 📸 스크린샷
- 방에 들어온 직후 소켓을 통해 `sync-is-running` 이벤트를 전파 받은걸 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/6eeff711-52a5-4f13-8021-458b8e5879d6)


closed #87 
