### PR TITLE
feat(timer-socket):서버 현재 시각을 알려주는 소켓 이벤트 추가

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -17,6 +17,7 @@ export const SOCKET_TIMER_EVENTS = {
   SYNC_IS_RUNNING: "sync-is-running",
   SYNC_ALL_PARTICIPANTS: "sync-all-participants",
   SYNC_CURRENT_CYCLES: "sync-current-cycles",
+  GET_SERVER_CURRENT_TIME: "get-server-current-time",
   ROOM_DELETED: "room-deleted",
   DELETE_ROOM: "delete-room",
   ERROR: "timer-error",

--- a/socket/room-detail/handlers/onGetServerCurrentTime.js
+++ b/socket/room-detail/handlers/onGetServerCurrentTime.js
@@ -1,0 +1,10 @@
+import dayjs from "dayjs";
+import { TIMESTAMP_FORMAT } from "../../../constants.js";
+
+const onGetServerCurrentTime = (socket, callback) => {
+  const serverCurrentTime = dayjs().format(TIMESTAMP_FORMAT);
+  
+  callback({ serverCurrentTime });
+};
+
+export default onGetServerCurrentTime;

--- a/socket/room-detail/handlers/onRoomDetailConnection.js
+++ b/socket/room-detail/handlers/onRoomDetailConnection.js
@@ -8,6 +8,7 @@ import getAllLinkedUserIdsFromNamespace from "../../helpers/getAllLinkedUserIdsF
 import getRoomIdFromNamespace from "../helpers/getRoomIdFromNamespace.js";
 import registerRoomDetailEventsInterceptor from "../helpers/registerRoomDetailEventsInterceptor.js";
 import onDeleteRoom from "./onDeleteRoom.js";
+import onGetServerCurrentTime from "./onGetServerCurrentTime.js";
 import onRoomDetailDisconnect from "./onRoomDetailDisconnect.js";
 import onStartCycles from "./onStartCycles.js";
 
@@ -43,6 +44,9 @@ const onConnection = async (socket) => {
   console.log("A user connected to room:", roomId);
 
   socket.on(SOCKET_TIMER_EVENTS.START_CYCLES, () => onStartCycles(socket));
+  socket.on(SOCKET_TIMER_EVENTS.GET_SERVER_CURRENT_TIME, (callback) =>
+    onGetServerCurrentTime(socket, callback)
+  );
   socket.on(SOCKET_TIMER_EVENTS.DELETE_ROOM, () => onDeleteRoom(socket));
   socket.on(SOCKET_DEFAULT_EVENTS.DISCONNECT, () =>
     onRoomDetailDisconnect(socket)


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- 서버의 현재 시각을 전달하는 `get-server-current-time` 리스닝 이벤트를 추가 했습니다.
- 클라이언트 측에서 타이머를 작동시킬 때, `Date.now()`가 컴퓨터 시스템 시간을 반영해서 생기는 시간오차를 해결하기 위해 서버의 현재 시각을 알려주는 소켓 이벤트를 추가 했습니다.

### PR Point
```ts
    socket.emit('get-server-current-time', ({ serverCurrentTime }) => {
      console.log(serverCurrentTime)
    })
```
- 프론트 코드의 `useEmitSocket`의 `useEffect`부분에 위와 같은 코드를 추가했을 때 잘 작동하는지 확인해 주세요.

### 📸 스크린샷

- 방에 입장한 직후

![image](https://github.com/user-attachments/assets/9b0b2e46-c793-4ceb-a4bc-59da730841aa)

closed #89 
