### PR TITLE
chore: docker의 timezone을 한국 시간대로 변경

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,3 +8,4 @@ services:
       - .env
     environment:
       NODE_ENV: production
+      TZ: "Asia/Seoul"


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- EC2와는 별개로 백엔드 서버가 돌아가고 있는 도커 내의 timezone이 한국 시간대로 설정 되어있지 않던 문제를 해결 했습니다.

closed #96 
