### PR TITLE
feat(auth): 카카오 구글 소셜 로그인 구현

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -107,12 +107,22 @@ const userController = {
         .json({ message: "이미 존재하는 닉네임 입니다." });
     }
 
-    await userService.socialSignup({
+    const userId = await userService.socialSignup({
       email,
       nickname,
       provider,
       socialAccessToken,
     });
+
+    const accessToken = userService.issueAccessToken({
+      userId,
+    });
+    res.cookie(ACCESS_TOKEN_KEY, accessToken, ACCESS_TOKEN_COOKIE_OPTIONS);
+
+    const refreshToken = await userService.createRefreshToken({
+      userId,
+    });
+    res.cookie(REFRESH_TOKEN_KEY, refreshToken, REFRESH_TOKEN_COOKIE_OPTIONS);
 
     return res.status(StatusCodes.CREATED).end();
   }),

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -79,6 +79,44 @@ const userController = {
     return res.status(StatusCodes.CREATED).end();
   }),
 
+  socialSignup: errorHandler(async (req, res) => {
+    const { connection } = req;
+    const { provider, email, nickname } = req.body;
+
+    const socialAccessToken = req.headers.authorization?.split("Bearer ")[1];
+    if (!socialAccessToken) {
+      return res
+        .status(StatusCodes.UNAUTHORIZED)
+        .json({ message: "토큰이 존재하지 않습니다." });
+    }
+
+    const userByEmail = await userService.getUserByEmail({ connection, email });
+    if (userByEmail) {
+      return res
+        .status(StatusCodes.CONFLICT)
+        .json({ message: "이미 존재하는 이메일 입니다." });
+    }
+
+    const userByNickname = await userService.getUserByNickname({
+      connection,
+      nickname,
+    });
+    if (userByNickname) {
+      return res
+        .status(StatusCodes.CONFLICT)
+        .json({ message: "이미 존재하는 닉네임 입니다." });
+    }
+
+    await userService.socialSignup({
+      email,
+      nickname,
+      provider,
+      socialAccessToken,
+    });
+
+    return res.status(StatusCodes.CREATED).end();
+  }),
+
   login: errorHandler(async (req, res) => {
     const { email, password } = req.body;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.609.0",
+        "axios": "^1.7.7",
         "camelcase-keys": "^9.1.3",
         "cookie": "^0.6.0",
         "cookie-parser": "^1.4.6",
@@ -1584,6 +1585,21 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1759,6 +1775,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1875,6 +1902,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -2124,6 +2159,38 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
+      "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -2768,6 +2835,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/Pogakco/BE#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.609.0",
+    "axios": "^1.7.7",
     "camelcase-keys": "^9.1.3",
     "cookie": "^0.6.0",
     "cookie-parser": "^1.4.6",

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -93,6 +93,20 @@ const userRepository = {
 
     await connection.query(SQL, [userId, refreshToken]);
   },
+
+  async findSocialLoginInfo({ connection, providerId, provider }) {
+    const SQL = `
+      SELECT *
+      FROM social_logins
+      WHERE
+        provider_id = ?
+        AND provider = ?
+    `;
+
+    const [data] = await connection.query(SQL, [providerId, provider]);
+
+    return isEmptyArray(data) ? null : data[0];
+  },
 };
 
 export default userRepository;

--- a/repositories/userRepository.js
+++ b/repositories/userRepository.js
@@ -27,11 +27,26 @@ const userRepository = {
     return isEmptyArray(data) ? null : data[0];
   },
 
-  async createUser({ connection, email, nickname, hashedPassword, salt }) {
+  async createUser({
+    connection,
+    email,
+    nickname,
+    hashedPassword,
+    salt,
+    isSocialLogin,
+  }) {
     const SQL =
-      "INSERT INTO `users` (`email`, `nickname`, `password`, `salt`) VALUES (?, ?, ?, ?)";
+      "INSERT INTO `users` (`email`, `nickname`, `password`, `salt`, `is_social_login`) VALUES (?, ?, ?, ?, ?)";
 
-    await connection.query(SQL, [email, nickname, hashedPassword, salt]);
+    const [result] = await connection.query(SQL, [
+      email,
+      nickname,
+      hashedPassword,
+      salt,
+      isSocialLogin ?? false,
+    ]);
+
+    return result;
   },
 
   async updateUser({
@@ -106,6 +121,15 @@ const userRepository = {
     const [data] = await connection.query(SQL, [providerId, provider]);
 
     return isEmptyArray(data) ? null : data[0];
+  },
+
+  async createSocialLoginInfo({ connection, userId, provider, providerId }) {
+    const SQL = `
+      INSERT INTO social_logins (user_id, provider, provider_id)
+      VALUES (?, ?, ?)
+    `;
+
+    await connection.query(SQL, [userId, provider, providerId]);
   },
 };
 

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -27,6 +27,12 @@ router.post(
 );
 
 router.post(
+  "/social-signup",
+  [...userValidator.getSocialSignupValidator()],
+  userController.socialSignup
+);
+
+router.post(
   "/login",
   [...userValidator.getLoginValidator()],
   userController.login

--- a/routers/userRouter.js
+++ b/routers/userRouter.js
@@ -15,6 +15,12 @@ router.post(
 );
 
 router.post(
+  "/social-auth",
+  [...userValidator.getSocialAuthValidator()],
+  userController.socialAuth
+);
+
+router.post(
   "/signup",
   [...userValidator.getSignupValidator()],
   userController.signup

--- a/services/userService.js
+++ b/services/userService.js
@@ -311,9 +311,28 @@ const userService = {
     }
   },
 
+  async getGoogleUserId({ socialAccessToken }) {
+    try {
+      const googleUser = (
+        await axios.get("https://www.googleapis.com/oauth2/v3/userinfo", {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+            Authorization: `Bearer ${socialAccessToken}`,
+          },
+        })
+      ).data;
+      return googleUser.sub;
+    } catch (error) {
+      throw error;
+    }
+  },
+
   async getSocialLoginProviderId({ socialAccessToken, provider }) {
     if (provider === "KAKAO") {
       return this.getKakaoUserId({ socialAccessToken });
+    }
+    if (provider === "GOOGLE") {
+      return this.getGoogleUserId({ socialAccessToken });
     }
   },
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -298,7 +298,7 @@ const userService = {
   async getKakaoUserId({ socialAccessToken }) {
     try {
       const kakaoUser = (
-        await axios.post(`${process.env.KAKAO_API_URL}/user/me`, null, {
+        await axios.post("https://kapi.kakao.com/v2/user/me", null, {
           headers: {
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
             Authorization: `Bearer ${socialAccessToken}`,

--- a/services/userService.js
+++ b/services/userService.js
@@ -187,6 +187,8 @@ const userService = {
       });
 
       await connection.commit();
+
+      return userId;
     } catch (error) {
       await connection.rollback();
       throw error;

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -13,6 +13,15 @@ const getPasswordRegex = () => {
   );
 };
 
+const createProviderChain = () => {
+  return body("provider")
+    .notEmpty()
+    .withMessage("provider를 입력해 주세요.")
+    .bail()
+    .isIn(["GOOGLE", "KAKAO"])
+    .withMessage("잘못된 provider 입니다.");
+};
+
 const createEmailChain = () => {
   return body("email")
     .notEmpty()
@@ -64,6 +73,10 @@ const createProfileImageChain = () => {
 };
 
 const userValidator = {
+  getSocialAuthValidator() {
+    return createValidator(createProviderChain);
+  },
+
   getSignupValidator() {
     return createValidator(
       createEmailChain,

--- a/validators/userValidator.js
+++ b/validators/userValidator.js
@@ -85,6 +85,14 @@ const userValidator = {
     );
   },
 
+  getSocialSignupValidator() {
+    return createValidator(
+      createEmailChain,
+      createNicknameChain,
+      createProviderChain
+    );
+  },
+
   getLoginValidator() {
     return createValidator(createEmailChain, createLoginPasswordChain);
   },


### PR DESCRIPTION
# Pull Request
### 작업한 내용
- OAuth2 카카오, 구글 소셜 로그인 및 회원가입 기능을 구현 했습니다.

<br />

### 작업 상세 내용
- 소셜 로그인 인증 API 구현
- 소셜 계정 회원가입 API 구현

<br />

### PR Point
- 변경사항 반영을 위해 데이터베이스 쿼리를 실행해주세요.
![image](https://github.com/user-attachments/assets/f4a0bc6f-8012-40e9-80b0-9546326cb78e)
- 프론트엔드 ```.env``` 파일을 구글 드라이브에서 받아서 프로젝트에 업데이트해주세요.
- 백엔드 프로젝트에서 `npm install` 커맨드를 실행해 주세요.(패키지 추가됨)
- 모바일 환경에서 카카오 로그인시 카카오톡 앱으로 이동시키기 위해 카카오 SDK 방식을 사용 했습니다.

<br />

### 소셜 로그인 로직 순서도
![제목 없는 다이어그램](https://github.com/user-attachments/assets/d368cc59-9a27-407b-871f-e8aa309179be)

<br />

### 참고 자료
백엔드 기능을 구현하면서 테스트할 때 작성한 프론트엔드 코드 입니다.

#### 카카오 SDK init
```html
<script
  src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js"
  integrity="sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4"
  crossorigin="anonymous"
></script>
<script>
  Kakao.init(import.meta.env.VITE_KAKAO_APP_KEY);
</script>
```

#### 소셜 로그인 버튼
```typescript
const isDevMode = import.meta.env.DEV;
const BASE_URL = isDevMode ? "http://localhost:5173" : "https://pogakco.site";
const GOOGLE_OAUTH_REDIRECT_URI = `${BASE_URL}/oauth/google`;
const KAKAO_OAUTH_REDIRECT_URI = `${BASE_URL}/oauth/kakao`;

...

<button
  onClick={() =>
    Kakao.Auth.authorize({
      redirectUri: KAKAO_OAUTH_REDIRECT_URI
    })
  }
>
  카카오 로그인
</button>
<a
  href={`https://accounts.google.com/o/oauth2/v2/auth?client_id=${
    import.meta.env.VITE_GOOGLE_CLIENT_ID
  }&redirect_uri=${GOOGLE_OAUTH_REDIRECT_URI}&response_type=code&scope=email`}
>
  구글 로그인
</a>
```

#### 리다이렉트 페이지
[OAuthRedirectPages.zip](https://github.com/user-attachments/files/16885083/OAuthRedirectPages.zip)

<br />

### 논의 사항
- 카카오 소셜 로그인시 ```email```을 필수(선택이 아닌)로 받아오려면 카카오측에 요청을 해야해서 일단은 **소셜 계정 회원가입 API**에서 ```email```과 ```nickname```을 받도록 구현 했습니다. 
- 소셜 계정은 비밀번호가 없어서 마이페이지 접근시 비밀번호 검증하는 로직을 제거하고, 비밀번호 변경 페이지와 API를 분리해서 구현해야 될 것 같습니다.

closed #99 
